### PR TITLE
docs/01-tutorial/04-communities.md: prevent infinite loop between /app <-> /?error=not-signed-in if (:uid session) but user has been deleted

### DIFF
--- a/content/docs/01-tutorial/04-communities.md
+++ b/content/docs/01-tutorial/04-communities.md
@@ -168,7 +168,8 @@ location to `/` instead of `/signin` while we're at it:
 +                             %%(:uid session))%%)]
 +      (handler (assoc ctx :user user))
 +      {:status 303
-+       :headers {"location" "/?error=not-signed-in"}})))
++       :headers {"location" "/?error=not-signed-in"}
++       :session (dissoc session :uid)})))
 ```
 
 That `xt/pull` call is a little complex; you may want to read up on


### PR DESCRIPTION
(actual fix instead of https://github.com/jacobobryant/biff/pull/228)

The cause of the infinite loop is this:

`/` uses middleware `wrap-redirect-signed-in`, which redirects a user to `/app` `if (some? (:uid session))`

=> `/app` uses middleware `wrap-signed-in`, which attempts to pull the profile of a user (+ other stuff; but _the key here is that it actually verifies that such a user exists that matches `(:uid session)`_). If `(:uid session)` exists _but said user is not to be found_ (say because of a db cleanup where this user is removed), the user is redirected to `/?error=not-signed-in`

=> back to `/` again (albeit with `error=not-signed-in` but no matter), where `wrap-redirect-signed-in`, detecting `(:uid session)` redirects to `/app` again.

I hope this makes sense?